### PR TITLE
(TEST) Holder-centric getters

### DIFF
--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -133,7 +133,6 @@ contract('StandardAssetRegistry', accounts => {
     it('returns an empty array for an inexistent address', async () => {
       const assets = await registry.assetsOf(NONE)
       const convertedAssets = assets.map(big => big.toString())
-      console.log(assets)
       convertedAssets.should.have.all.members([])
     })
   })

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -1,4 +1,5 @@
 import assertRevert from './helpers/assertRevert'
+
 const BigNumber = web3.BigNumber
 
 const StandardAssetRegistry = artifacts.require('StandardAssetRegistryTest')
@@ -70,6 +71,70 @@ contract('StandardAssetRegistry', accounts => {
       await registry.generate(100, anotherUser, sentByCreator)
       totalSupply = await registry.totalSupply()
       totalSupply.should.be.bignumber.equal(3)
+    })
+  })
+
+  describe('assetCount', () => {
+    it('has an amount of assets equivalent to the created assets', async () => {
+      const assetCount = await registry.assetsCount(creator)
+      assetCount.should.be.bignumber.equal(2)
+    })
+
+    it('has an amount of assets equivalent to the amount sent to the beneficiary', async () => {
+      await registry.generate(3, user, '', sentByCreator)
+      const assetCount = await registry.assetsCount(user)
+      assetCount.should.be.bignumber.equal(1)
+    })
+
+    it('should consider destroyed assets', async () => {
+      await registry.destroy(1)
+      const assetCount = await registry.assetsCount(creator)
+      assetCount.should.be.bignumber.equal(1)
+    })
+
+    it('should return 0 for an inexistent address', async () => {
+      const assetCount = await registry.assetsCount(NONE)
+      assetCount.should.be.bignumber.equal(0)
+    })
+  })
+
+  describe('assetByIndex', () => {
+    it('returns the id for the first asset of the holder', async () => {
+      const assets = await registry.assetByIndex(creator, 0)
+      assets.should.be.bignumber.equal(0)
+    })
+
+    it('reverts if the index is out of bounds', async () => {
+      await assertRevert(registry.assetByIndex(creator, 10))
+    })
+
+    it('reverts if the index is out of bounds (negative)', async () => {
+      await assertRevert(registry.assetByIndex(creator, -10))
+    })
+
+    it('reverts for an inexistent address', async () => {
+      await assertRevert(registry.assetByIndex(NONE, 0))
+    })
+  })
+
+  describe('assetsOf', () => {
+    it('returns the created assets', async () => {
+      const assets = await registry.assetsOf(creator)
+      const convertedAssets = assets.map(big => big.toString())
+      convertedAssets.should.have.all.members(['0', '1'])
+    })
+
+    it('returns an empty array for an address with no assets', async () => {
+      const assets = await registry.assetsOf(user)
+      const convertedAssets = assets.map(big => big.toString())
+      convertedAssets.should.have.all.members([])
+    })
+
+    it('returns an empty array for an inexistent address', async () => {
+      const assets = await registry.assetsOf(NONE)
+      const convertedAssets = assets.map(big => big.toString())
+      console.log(assets)
+      convertedAssets.should.have.all.members([])
     })
   })
 

--- a/test/StandardAssetRegistry.js
+++ b/test/StandardAssetRegistry.js
@@ -80,7 +80,7 @@ contract('StandardAssetRegistry', accounts => {
       assetCount.should.be.bignumber.equal(2)
     })
 
-    it('has an amount of assets equivalent to the amount sent to the beneficiary', async () => {
+    xit('has an amount of assets equivalent to the amount sent to the beneficiary', async () => {
       await registry.generate(3, user, '', sentByCreator)
       const assetCount = await registry.assetsCount(user)
       assetCount.should.be.bignumber.equal(1)


### PR DESCRIPTION
No tests for `allAssetsOf` as I plan to merge it with `assetsOf` in https://github.com/decentraland/erc821/pull/5
Skipped a test due to https://github.com/trufflesuite/truffle/issues/737