### PR TITLE
Major improvements to ERC821

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:latest
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -22,8 +22,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
 
       - run: npm install
 

--- a/contracts/IAssetRegistry.sol
+++ b/contracts/IAssetRegistry.sol
@@ -5,24 +5,27 @@ interface IAssetRegistry {
   /**
    * Global Registry getter functions
    */
-  function name() public constant returns (string);
-  function symbol() public constant returns (string);
-  function description() public constant returns (string);
-  function totalSupply() public constant returns (uint256);
+  function name() public view returns (string);
+  function symbol() public view returns (string);
+  function description() public view returns (string);
+  function totalSupply() public view returns (uint256);
 
   /**
    * Asset-centric getter functions
    */
-  function exists(uint256 assetId) public constant returns (bool);
-  function holderOf(uint256 assetId) public constant returns (address);
-  function assetData(uint256 assetId) public constant returns (string);
+  function exists(uint256 assetId) public view returns (bool);
+
+  function holderOf(uint256 assetId) public view returns (address);
+  function safeHolderOf(uint256 assetId) public view returns (address);
+
+  function assetData(uint256 assetId) public view returns (string);
 
   /**
    * Holder-centric getter functions
    */
-  function assetsCount(address holder) public constant returns (uint256);
-  function assetByIndex(address holder, uint256 index) public constant returns (uint256);
-  function assetsOf(address holder) public constant returns (uint256[]);
+  function assetCount(address holder) public view returns (uint256);
+  function assetByIndex(address holder, uint256 index) public view returns (uint256);
+  function assetsOf(address holder) external view returns (uint256[]);
 
   /**
    * Transfer Operations
@@ -30,17 +33,6 @@ interface IAssetRegistry {
   function transfer(address to, uint256 assetId) public;
   function transfer(address to, uint256 assetId, bytes userData) public;
   function operatorTransfer(address to, uint256 assetId, bytes userData, bytes operatorData) public;
-
-  /**
-   * Data modification operations
-   */
-  function update(uint256 assetId, string data) public;
-
-  /**
-   * Supply-altering operations
-   */
-  function generate(uint256 assetId, string data) public;
-  function destroy(uint256 assetId) public;
 
   /**
    * Authorization operations
@@ -51,7 +43,7 @@ interface IAssetRegistry {
    * Authorization getters
    */
   function isOperatorAuthorizedFor(address operator, address assetHolder)
-    public constant returns (bool);
+    public view returns (bool);
 
   /**
    * Events
@@ -64,22 +56,11 @@ interface IAssetRegistry {
     bytes userData,
     bytes operatorData
   );
-  event Create(
-    address indexed holder,
-    uint256 indexed assetId,
-    address indexed operator,
-    string data
-  );
   event Update(
     uint256 indexed assetId,
     address indexed holder,
     address indexed operator,
     string data
-  );
-  event Destroy(
-    address indexed holder,
-    uint256 indexed assetId,
-    address indexed operator
   );
   event AuthorizeOperator(
     address indexed operator,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erc821",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Contract for ERC 821",
   "scripts": {
     "test": "scripts/test.sh",
@@ -35,7 +35,7 @@
     "eslint": "^4.15.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.4.0",
-    "ethereumjs-testrpc": "^6.0.1",
+    "ganache-cli": "^6.0.3",
     "mocha": "^3.5.3",
     "npx": "^9.7.1",
     "pre-commit": "^1.2.2",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,23 +7,23 @@ set -o errexit
 trap cleanup EXIT
 
 cleanup() {
-  # Kill the testrpc instance that we started (if we started one and if it's still running).
-  if [ -n "$testrpc_pid" ] && ps -p $testrpc_pid > /dev/null; then
-    kill -9 $testrpc_pid
+  # Kill the ganache instance that we started (if we started one and if it's still running).
+  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
+    kill -9 $ganache_pid
   fi
 }
 
 if [ "$SOLIDITY_COVERAGE" = true ]; then
-  testrpc_port=8555
+  ganache_port=8555
 else
-  testrpc_port=18545
+  ganache_port=18545
 fi
 
-testrpc_running() {
-  nc -z localhost "$testrpc_port"
+ganache_running() {
+  nc -z localhost "$ganache_port"
 }
 
-start_testrpc() {
+start_ganache() {
   # We define 10 accounts with balance 1M ether, needed for high-value tests.
   local accounts=(
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200,1000000000000000000000000"
@@ -38,28 +38,16 @@ start_testrpc() {
     --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501209,1000000000000000000000000"
   )
 
-  if [ "$SOLIDITY_COVERAGE" = true ]; then
-    node_modules/.bin/testrpc-sc --gasLimit 100000000 --port "$testrpc_port" "${accounts[@]}" > /dev/null &
-  else
-    node_modules/.bin/testrpc --gasLimit 1000000000 "${accounts[@]}" --port "$testrpc_port" > /dev/null &
-  fi
+  node_modules/.bin/ganache-cli --gasLimit 1000000000 "${accounts[@]}" --port "$ganache_port" > /dev/null &
 
-  testrpc_pid=$!
+  ganache_pid=$!
 }
 
-if testrpc_running; then
-  echo "Using existing testrpc instance"
+if ganache_running; then
+  echo "Using existing ganache instance"
 else
-  echo "Starting our own testrpc instance"
-  start_testrpc
+  echo "Starting our own ganache instance"
+  start_ganache
 fi
 
-if [ "$SOLIDITY_COVERAGE" = true ]; then
-  node_modules/.bin/solidity-coverage
-
-  if [ "$CONTINUOUS_INTEGRATION" = true ]; then
-    cat coverage/lcov.info | node_modules/.bin/coveralls
-  fi
-else
-  node_modules/.bin/truffle test "$@"
-fi
+node_modules/.bin/truffle test "$@"

--- a/test/StandardAssetRegistryTest.sol
+++ b/test/StandardAssetRegistryTest.sol
@@ -11,7 +11,18 @@ contract StandardAssetRegistryTest is StandardAssetRegistry {
   }
 
   function isContractProxy(address addr) public view returns (bool) {
-    return isContract(addr);
+    return _isContract(addr);
   }
 
+  function generate(uint256 assetId, address beneficiary, string data) public {
+    _generate(assetId, beneficiary, data);
+  }
+
+  function update(uint256 assetId, string data) public {
+    _update(assetId, data);
+  }
+
+  function destroy(uint256 assetId) public {
+    _destroy(assetId);
+  }
 }


### PR DESCRIPTION
This PR:

* Changes all `constant` to `view`
* Modifies `assetsOf` to `external` as per #9
* Changes `update`, `generate`, and `destroy` to be internal (UNIX philosophy: define mechanics, not policy).
* Adds `safeHolderOf` that fails on non-existent assetId
* Drops the `Create` and `Destroy` events in favor of `Transfer` with null `from` or null `to`